### PR TITLE
Add redis config and basic JobQueue test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # Database Configuration
 DATABASE_URL=postgresql://judge0:judge0_password@localhost:5432/judge0
 
+# Redis configuration
+REDIS_URL=redis://localhost:6379/0
+
 # Alternative SQLite Database (for development)
 # DATABASE_URL=sqlite:///./judge0.db
 

--- a/.gitignore
+++ b/.gitignore
@@ -165,9 +165,10 @@ temp/
 Dockerfile.dev
 
 # Test files (development only)
-test_*.py
-*_test.py
-tests/
+# Uncomment the lines below to exclude tests from version control.
+# test_*.py
+# *_test.py
+# tests/
 
 # Coverage reports
 .coverage

--- a/shared/config.py
+++ b/shared/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     api_host: str = Field(default="0.0.0.0", description="API host")
     api_port: int = Field(default=8080, description="API port")
     debug: bool = Field(default=False, description="Debug mode")
+    redis_url: str = Field('redis://localhost:6379/0', description='Redis connection URL')
     
     # Worker settings
     max_workers: int = Field(default=4, description="Maximum number of workers")

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is in sys.path when running tests directly
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from shared.queue import JobQueue
+
+
+def test_job_queue_connection_params():
+    queue = JobQueue()
+    conn_kwargs = queue.redis_client.connection_pool.connection_kwargs
+    assert conn_kwargs.get('host') == 'localhost'
+    assert conn_kwargs.get('port') == 6379
+    assert conn_kwargs.get('db') == 0


### PR DESCRIPTION
## Summary
- support `redis_url` in configuration
- document redis URL in `.env.example`
- allow committing test files and add a test for `JobQueue`

## Testing
- `pip install redis rq` *(fails: Tunnel connection failed)*
- `pytest tests/test_job_queue.py -q` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_687e83b4a7c0832884a57a2889e3cf43